### PR TITLE
Force uppercase in names

### DIFF
--- a/src/reports/modified-lar/index.jsx
+++ b/src/reports/modified-lar/index.jsx
@@ -36,7 +36,9 @@ class ModifiedLar extends React.Component {
       .then(result => {
         this.setState({
           status: { id: 2, message: 'ready' },
-          institutions: result.institutions
+          institutions: result.institutions.map(v => {
+            return { ...v, name: v.name.toUpperCase() }
+          })
         })
       })
       .catch(error => {


### PR DESCRIPTION
Closes https://github.com/cfpb/hmda-pub-ui/issues/20
~4% of the names in the filers endpoint aren't uppercased, this fixes that by modifying the returned object so the comparisons always work (but also so `.toUpperCase()` isn't being constantly run)