### PR TITLE
Adds table 12-2

### DIFF
--- a/src/reports/Report.jsx
+++ b/src/reports/Report.jsx
@@ -40,10 +40,12 @@ class Report extends React.Component {
   }
 
   selectReport(report) {
-    if (report.table.match(/^1$/)) return <Tables.One report={report} />
-    if (report.table.match(/^4-/)) return <Tables.Four report={report} />
-    if (report.table.match(/^5-/)) return <Tables.Five report={report} />
-    if (report.table.match(/^11-/)) return <Tables.Eleven report={report} />
+    const table = report.table
+    if (table.match(/^1$/)) return <Tables.One report={report} />
+    if (table.match(/^4-/)) return <Tables.Four report={report} />
+    if (table.match(/^5-/)) return <Tables.Five report={report} />
+    if (table.match(/^11-/)) return <Tables.Eleven report={report} />
+    if (table.match(/^12-2$/)) return <Tables.TwelveTwo report={report} />
   }
 
   render() {

--- a/src/reports/tables/TwelveTwo.jsx
+++ b/src/reports/tables/TwelveTwo.jsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const renderData = (report, label) => {
+  return (
+    <React.Fragment>
+      {renderCharacteristicTitle('Borrower Characteristics')}
+      {mapCharacteristic(report.borrowerCharacteristics, label)}
+      {renderCharacteristicTitle('Census Tract Characteristics')}
+      {mapCharacteristic(report.censusTractCharacteristics, label)}
+    </React.Fragment>
+  )
+}
+
+const mapCharacteristic = (arr, label) => {
+  return arr.map(characteristic => {
+    return renderCharacteristic(characteristic, label)
+  })
+}
+
+const renderCharacteristicTitle = key => {
+  return (
+    <tr className="characteristic-grey-title" key={key}>
+      <th
+        colSpan={15}
+        style={{
+          borderTopWidth: '2px',
+          fontWeight: 'bold',
+          textTransform: 'uppercase',
+          backgroundColor: '#f1f1f1'
+        }}
+      >
+        {key}
+      </th>
+    </tr>
+  )
+}
+
+const renderCharacteristic = (characteristic, label) => {
+  let name, currChar
+  Object.keys(characteristic).forEach(key => {
+    if (key === 'characteristic') name = characteristic[key]
+    else currChar = characteristic[key]
+  })
+
+  return [
+    <tr className="characteristic-title" key={name}>
+      <th
+        colSpan={15}
+        style={{
+          borderTopWidth: '2px',
+          textTransform: 'uppercase',
+          fontWeight: 'bold'
+        }}
+      >
+        {name}
+      </th>
+    </tr>,
+    currChar.map((detailObj, index) => {
+      let detail, pricing
+      Object.keys(detailObj).forEach(key => {
+        if (key === 'pricingInformation') pricing = detailObj[key]
+        else detail = detailObj[key]
+      })
+
+      return (
+        <tr key={name + index}>
+          <th>{detail}</th>
+          {pricing.map((priceObj, index) => {
+            return (
+              <td>{label === 'NUMBER' ? priceObj.count : priceObj.value}</td>
+            )
+          })}
+        </tr>
+      )
+    })
+  ]
+}
+
+const makeTable = (report, label) => {
+  return (
+    <table style={{ fontSize: '.75em' }}>
+      <thead>
+        <tr>
+          <th width="20%" rowSpan={2}>
+            {`BORROWER OR CENSUS TRACT CHARACTERISTICS (${label})`}
+          </th>
+          <th rowSpan={2} width="6.667%">
+            No Reported Pricing Data
+          </th>
+          <th rowSpan={2} width="6.667%">
+            Reported Pricing Data
+          </th>
+          <th colSpan={9} width="60%">
+            Percentage Points above Average Prime Offer Rate (Only Includes
+            Loans with Apr above the Threshold)
+          </th>
+        </tr>
+        <tr>
+          <th width="6.667%">1.50 - 1.99</th>
+          <th width="6.667%">2.00 - 2.49</th>
+          <th width="6.667%">2.50 - 2.99</th>
+          <th width="6.667%">3.00 - 3.99</th>
+          <th width="6.667%">4.00 - 4.99</th>
+          <th width="6.667%">5.00 - 5.99</th>
+          <th width="6.667%">6 or More</th>
+          <th width="6.667%">Mean</th>
+          <th width="6.667%">Median</th>
+        </tr>
+      </thead>
+      <tbody>{renderData(report, label)}</tbody>
+    </table>
+  )
+}
+
+const TwelveTwo = props => {
+  const { report } = props
+  if (!report) return null
+
+  return (
+    <React.Fragment>
+      {makeTable(report, 'NUMBER')}
+      {makeTable(report, "$000's")}
+    </React.Fragment>
+  )
+}
+
+TwelveTwo.propTypes = {
+  report: PropTypes.object
+}
+
+export default TwelveTwo

--- a/src/reports/tables/index.jsx
+++ b/src/reports/tables/index.jsx
@@ -2,7 +2,6 @@ import One from './One.jsx'
 import Four from './Four.jsx'
 import Five from './Five.jsx'
 import Eleven from './Eleven.jsx'
-import TwelveOne from './TwelveOne.jsx'
 import TwelveTwo from './TwelveTwo.jsx'
 
 export default {
@@ -10,6 +9,5 @@ export default {
   Four,
   Five,
   Eleven,
-  TwelveOne,
   TwelveTwo
 }

--- a/src/reports/tables/index.jsx
+++ b/src/reports/tables/index.jsx
@@ -2,10 +2,14 @@ import One from './One.jsx'
 import Four from './Four.jsx'
 import Five from './Five.jsx'
 import Eleven from './Eleven.jsx'
+import TwelveOne from './TwelveOne.jsx'
+import TwelveTwo from './TwelveTwo.jsx'
 
 export default {
   One,
   Four,
   Five,
-  Eleven
+  Eleven,
+  TwelveOne,
+  TwelveTwo
 }


### PR DESCRIPTION
With the same caveat as #56, (note https://github.com/cfpb/hmda-platform/issues/1589), this adds Table 12-2 in the same format as the 2016 data.