### PR TITLE
Fixup rerenders

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -1,0 +1,230 @@
+'use strict'
+//Override of https://github.com/JedWatson/react-select to prevent needless Option rerenders
+Object.defineProperty(exports, '__esModule', {
+  value: true
+})
+
+var _createClass = (function() {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i]
+      descriptor.enumerable = descriptor.enumerable || false
+      descriptor.configurable = true
+      if ('value' in descriptor) descriptor.writable = true
+      Object.defineProperty(target, descriptor.key, descriptor)
+    }
+  }
+  return function(Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps)
+    if (staticProps) defineProperties(Constructor, staticProps)
+    return Constructor
+  }
+})()
+
+var _classnames = require('classnames')
+
+var _classnames2 = _interopRequireDefault(_classnames)
+
+var _propTypes = require('prop-types')
+
+var _propTypes2 = _interopRequireDefault(_propTypes)
+
+var _react = require('react')
+
+var _react2 = _interopRequireDefault(_react)
+
+var _blockEvent = require('../node_modules/react-select/lib/utils/blockEvent')
+
+var _blockEvent2 = _interopRequireDefault(_blockEvent)
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj }
+}
+
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError('Cannot call a class as a function')
+  }
+}
+
+function _possibleConstructorReturn(self, call) {
+  if (!self) {
+    throw new ReferenceError(
+      "this hasn't been initialised - super() hasn't been called"
+    )
+  }
+  return call && (typeof call === 'object' || typeof call === 'function')
+    ? call
+    : self
+}
+
+function _inherits(subClass, superClass) {
+  if (typeof superClass !== 'function' && superClass !== null) {
+    throw new TypeError(
+      'Super expression must either be null or a function, not ' +
+        typeof superClass
+    )
+  }
+  subClass.prototype = Object.create(superClass && superClass.prototype, {
+    constructor: {
+      value: subClass,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    }
+  })
+  if (superClass)
+    Object.setPrototypeOf
+      ? Object.setPrototypeOf(subClass, superClass)
+      : (subClass.__proto__ = superClass)
+}
+
+var Option = (function(_React$Component) {
+  _inherits(Option, _React$Component)
+
+  function Option(props) {
+    _classCallCheck(this, Option)
+
+    var _this = _possibleConstructorReturn(
+      this,
+      (Option.__proto__ || Object.getPrototypeOf(Option)).call(this, props)
+    )
+
+    _this.handleMouseDown = _this.handleMouseDown.bind(_this)
+    _this.handleMouseEnter = _this.handleMouseEnter.bind(_this)
+    _this.handleMouseMove = _this.handleMouseMove.bind(_this)
+    _this.handleTouchStart = _this.handleTouchStart.bind(_this)
+    _this.handleTouchEnd = _this.handleTouchEnd.bind(_this)
+    _this.handleTouchMove = _this.handleTouchMove.bind(_this)
+    _this.onFocus = _this.onFocus.bind(_this)
+    return _this
+  }
+
+  _createClass(Option, [
+    {
+      key: 'handleMouseDown',
+      value: function handleMouseDown(event) {
+        event.preventDefault()
+        event.stopPropagation()
+        this.props.onSelect(this.props.option, event)
+      }
+    },
+    {
+      key: 'handleMouseEnter',
+      value: function handleMouseEnter(event) {
+        this.onFocus(event)
+      }
+    },
+    {
+      key: 'shouldComponentUpdate',
+      value: function scu(props, state) {
+        var keys = Object.keys(props)
+        for (var i = 0; i < keys.length; i++) {
+          var key = keys[i]
+          if (props[key] !== this.props[key]) return true
+        }
+        if (state !== this.state) return true
+        return false
+      }
+    },
+    {
+      key: 'handleMouseMove',
+      value: function handleMouseMove(event) {
+        this.onFocus(event)
+      }
+    },
+    {
+      key: 'handleTouchEnd',
+      value: function handleTouchEnd(event) {
+        // Check if the view is being dragged, In this case
+        // we don't want to fire the click event (because the user only wants to scroll)
+        if (this.dragging) return
+
+        this.handleMouseDown(event)
+      }
+    },
+    {
+      key: 'handleTouchMove',
+      value: function handleTouchMove() {
+        // Set a flag that the view is being dragged
+        this.dragging = true
+      }
+    },
+    {
+      key: 'handleTouchStart',
+      value: function handleTouchStart() {
+        // Set a flag that the view is not being dragged
+        this.dragging = false
+      }
+    },
+    {
+      key: 'onFocus',
+      value: function onFocus(event) {
+        if (!this.props.isFocused) {
+          this.props.onFocus(this.props.option, event)
+        }
+      }
+    },
+    {
+      key: 'render',
+      value: function render() {
+        var _props = this.props,
+          option = _props.option,
+          instancePrefix = _props.instancePrefix,
+          optionIndex = _props.optionIndex
+
+        var className = (0, _classnames2.default)(
+          this.props.className,
+          option.className
+        )
+
+        return option.disabled
+          ? _react2.default.createElement(
+              'div',
+              {
+                className: className,
+                onMouseDown: _blockEvent2.default,
+                onClick: _blockEvent2.default
+              },
+              this.props.children
+            )
+          : _react2.default.createElement(
+              'div',
+              {
+                className: className,
+                style: option.style,
+                role: 'option',
+                'aria-label': option.label,
+                onMouseDown: this.handleMouseDown,
+                onMouseEnter: this.handleMouseEnter,
+                onMouseMove: this.handleMouseMove,
+                onTouchStart: this.handleTouchStart,
+                onTouchMove: this.handleTouchMove,
+                onTouchEnd: this.handleTouchEnd,
+                id: instancePrefix + '-option-' + optionIndex,
+                title: option.title
+              },
+              this.props.children
+            )
+      }
+    }
+  ])
+
+  return Option
+})(_react2.default.Component)
+
+Option.propTypes = {
+  children: _propTypes2.default.node,
+  className: _propTypes2.default.string, // className (based on mouse position)
+  instancePrefix: _propTypes2.default.string.isRequired, // unique prefix for the ids (used for aria)
+  isDisabled: _propTypes2.default.bool, // the option is disabled
+  isFocused: _propTypes2.default.bool, // the option is focused
+  isSelected: _propTypes2.default.bool, // the option is selected
+  onFocus: _propTypes2.default.func, // method to handle mouseEnter on option element
+  onSelect: _propTypes2.default.func, // method to handle click on option element
+  onUnfocus: _propTypes2.default.func, // method to handle mouseLeave on option element
+  option: _propTypes2.default.object.isRequired, // object that is base for that option
+  optionIndex: _propTypes2.default.number // index of the option, used to generate unique ids for aria
+}
+
+exports.default = Option

--- a/src/reports/Selector.jsx
+++ b/src/reports/Selector.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Select from 'react-select'
+import Option from '../Option.js'
 import Header from '../common/Header.jsx'
 import LoadingIcon from '../common/LoadingIcon.jsx'
 import { DISCLOSURE_REPORTS } from '../constants/disclosure-reports.js'
@@ -122,6 +123,7 @@ class Selector extends React.Component {
             openOnFocus
             simpleValue
             options={options}
+            optionComponent={Option}
           />
         ) : (
           <LoadingIcon />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5334,7 +5334,7 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-select@^1.2.1:
+react-select@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
   dependencies:


### PR DESCRIPTION
Prevents all options from being rerendered when react-select renders the highlight for the currently hovered option