### PR TITLE
sort based on tract to make tables more readable

### DIFF
--- a/src/reports/tables/One.jsx
+++ b/src/reports/tables/One.jsx
@@ -88,6 +88,20 @@ const renderDispositionValues = (values, key, key2) => {
 const One = props => {
   if (!props.report) return null
 
+  const sortedTracts = props.report.tracts.sort(function(tractA, tractB) {
+    const idA = tractA.tract.toUpperCase()
+    const idB = tractB.tract.toUpperCase()
+
+    if (idA < idB) {
+      return -1
+    }
+    if (idA > idB) {
+      return 1
+    }
+
+    return 0
+  })
+
   let colWidth = '5.7%'
   if (props.reportType === 'aggregate') colWidth = '5%'
 
@@ -184,7 +198,7 @@ const One = props => {
             </td>
           </tr>
         ) : (
-          renderData(props.report.tracts, props.reportType)
+          renderData(sortedTracts, props.reportType)
         )}
       </tbody>
     </table>

--- a/src/reports/tables/Two.jsx
+++ b/src/reports/tables/Two.jsx
@@ -32,6 +32,20 @@ const renderValues = (values, key) => {
 const Two = props => {
   if (!props.report) return null
 
+  const sortedTracts = props.report.tracts.sort(function(tractA, tractB) {
+    const idA = tractA.tract.toUpperCase()
+    const idB = tractB.tract.toUpperCase()
+
+    if (idA < idB) {
+      return -1
+    }
+    if (idA > idB) {
+      return 1
+    }
+
+    return 0
+  })
+
   return (
     <table style={{ fontSize: '.75em' }}>
       <thead>
@@ -114,7 +128,7 @@ const Two = props => {
             </td>
           </tr>
         ) : (
-          renderData(props.report.tracts)
+          renderData(sortedTracts)
         )}
       </tbody>
     </table>


### PR DESCRIPTION
Closes #106 

This sorts based on `STATE/COUNTY/TRACT NUMBER` since the JSON returned in the file lists the tract that way (e.g. `"tract": "NY/Broome County/0130.00"`).

_I did create the same function twice since it's pretty straightfoward. If we end up needing it even more I think we can create a `util` then._