### PR TITLE
Table heading css

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -17,5 +17,5 @@
 @import 'reports/Results.scss';
 @import 'reports/SearchList.scss';
 @import 'reports/ProgressCard.scss';
+@import 'reports/Report.scss';
 @import 'reports/Selector.scss';
-@import 'reports/tables/tables.scss';

--- a/src/app.scss
+++ b/src/app.scss
@@ -19,3 +19,8 @@
 @import 'reports/ProgressCard.scss';
 @import 'reports/Report.scss';
 @import 'reports/Selector.scss';
+
+hr {
+  border-bottom: none;
+  border-top: 1px solid $color-gray-light;
+}

--- a/src/common/Header.jsx
+++ b/src/common/Header.jsx
@@ -9,6 +9,7 @@ const makeHeadingLink = (headingText, headingLink) => {
 const renderHeading = (type, heading) => {
   if (type === 1) return <h1>{heading}</h1>
   if (type === 2) return <h2>{heading}</h2>
+  if (type === 3) return <h3>{heading}</h3>
   if (type === 4) return <h4>{heading}</h4>
 }
 
@@ -39,7 +40,7 @@ const Header = props => {
 }
 
 Header.propTypes = {
-  type: PropTypes.oneOf([1, 2, 4]),
+  type: PropTypes.oneOf([1, 2, 3, 4]),
   headingText: PropTypes.string,
   paragraphText: PropTypes.string,
   headingLink: PropTypes.string

--- a/src/common/Header.scss
+++ b/src/common/Header.scss
@@ -1,6 +1,7 @@
 .header {
   h1,
   h2,
+  h3,
   h4 {
     margin-bottom: 0;
   }

--- a/src/reports/Aggregate.jsx
+++ b/src/reports/Aggregate.jsx
@@ -69,25 +69,29 @@ class Aggregate extends React.Component {
           {header}
 
           {params.stateId ? (
-            <React.Fragment>
-              <div className="ProgressCards usa-grid-full">
+            <ol className="ProgressCards usa-grid-full">
+              <li>
                 <ProgressCard
                   title="state"
                   name={state.name}
                   id={state.id}
                   link={`/aggregate-reports/${params.year}`}
                 />
+              </li>
 
-                {params.msaMdId ? (
+              {params.msaMdId ? (
+                <li>
                   <ProgressCard
                     title="MSA/MD"
                     name={msaMd.name}
                     id={msaMd.id}
                     link={`/aggregate-reports/${params.year}/${state.id}`}
                   />
-                ) : null}
+                </li>
+              ) : null}
 
-                {params.reportId ? (
+              {params.reportId ? (
+                <li>
                   <ProgressCard
                     title="report"
                     name={report.name}
@@ -96,10 +100,9 @@ class Aggregate extends React.Component {
                       msaMd.id
                     }`}
                   />
-                ) : null}
-              </div>
-              <hr />
-            </React.Fragment>
+                </li>
+              ) : null}
+            </ol>
           ) : null}
 
           {params.stateId ? (

--- a/src/reports/Aggregate.jsx
+++ b/src/reports/Aggregate.jsx
@@ -43,6 +43,8 @@ class Aggregate extends React.Component {
     detailsCache.msaMds[msaMd.id] = msaMd
   }
 
+  renderChoices(params) {}
+
   render() {
     const { params } = this.props.match
     const state = detailsCache.states[params.stateId]
@@ -55,51 +57,59 @@ class Aggregate extends React.Component {
 
     const header = (
       <Header
-        type={2}
+        type={1}
         headingText="MSA/MD Aggregate Reports"
         paragraphText="These reports summarize lending activity by MSA/MD."
       />
     )
 
     return (
-      <>
+      <React.Fragment>
         <div className="usa-grid" id="main-content">
           {header}
+
           {params.stateId ? (
-            <>
-              <ProgressCard
-                title="state"
-                name={state.name}
-                id={state.id}
-                link={`/aggregate-reports/${params.year}`}
-              />
-              {params.msaMdId ? (
-                <>
+            <React.Fragment>
+              <div className="ProgressCards usa-grid-full">
+                <ProgressCard
+                  title="state"
+                  name={state.name}
+                  id={state.id}
+                  link={`/aggregate-reports/${params.year}`}
+                />
+
+                {params.msaMdId ? (
                   <ProgressCard
                     title="MSA/MD"
                     name={msaMd.name}
                     id={msaMd.id}
                     link={`/aggregate-reports/${params.year}/${state.id}`}
                   />
-                  {params.reportId ? (
-                    <>
-                      <ProgressCard
-                        title="report"
-                        name={report.name}
-                        id={report.id}
-                        link={`/aggregate-reports/${params.year}/${state.id}/${
-                          msaMd.id
-                        }`}
-                      />
-                    </>
-                  ) : (
-                    <Reports {...this.props} />
-                  )}
-                </>
-              ) : (
-                <MsaMds {...this.props} selectorCallback={this.setMsaMd} />
-              )}
-            </>
+                ) : null}
+
+                {params.reportId ? (
+                  <ProgressCard
+                    title="report"
+                    name={report.name}
+                    id={report.id}
+                    link={`/aggregate-reports/${params.year}/${state.id}/${
+                      msaMd.id
+                    }`}
+                  />
+                ) : null}
+              </div>
+              <hr />
+            </React.Fragment>
+          ) : null}
+
+          {params.stateId ? (
+            params.msaMdId ? (
+              params.reportId ? null : (
+                <Reports {...this.props} />
+              )
+            ) : (
+              <MsaMds {...this.props} selectorCallback={this.setMsaMd} />
+            )
           ) : (
             <Select
               onChange={this.handleChange}
@@ -113,8 +123,9 @@ class Aggregate extends React.Component {
             />
           )}
         </div>
+
         {params.reportId ? <Report {...this.props} /> : null}
-      </>
+      </React.Fragment>
     )
   }
 }

--- a/src/reports/Aggregate.jsx
+++ b/src/reports/Aggregate.jsx
@@ -69,40 +69,43 @@ class Aggregate extends React.Component {
           {header}
 
           {params.stateId ? (
-            <ol className="ProgressCards usa-grid-full">
-              <li>
-                <ProgressCard
-                  title="state"
-                  name={state.name}
-                  id={state.id}
-                  link={`/aggregate-reports/${params.year}`}
-                />
-              </li>
-
-              {params.msaMdId ? (
+            <React.Fragment>
+              <ol className="ProgressCards usa-grid-full">
                 <li>
                   <ProgressCard
-                    title="MSA/MD"
-                    name={msaMd.name}
-                    id={msaMd.id}
-                    link={`/aggregate-reports/${params.year}/${state.id}`}
+                    title="state"
+                    name={state.name}
+                    id={state.id}
+                    link={`/aggregate-reports/${params.year}`}
                   />
                 </li>
-              ) : null}
 
-              {params.reportId ? (
-                <li>
-                  <ProgressCard
-                    title="report"
-                    name={report.name}
-                    id={report.id}
-                    link={`/aggregate-reports/${params.year}/${state.id}/${
-                      msaMd.id
-                    }`}
-                  />
-                </li>
-              ) : null}
-            </ol>
+                {params.msaMdId ? (
+                  <li>
+                    <ProgressCard
+                      title="MSA/MD"
+                      name={msaMd.name}
+                      id={msaMd.id}
+                      link={`/aggregate-reports/${params.year}/${state.id}`}
+                    />
+                  </li>
+                ) : null}
+
+                {params.reportId ? (
+                  <li>
+                    <ProgressCard
+                      title="report"
+                      name={report.name}
+                      id={report.id}
+                      link={`/aggregate-reports/${params.year}/${state.id}/${
+                        msaMd.id
+                      }`}
+                    />
+                  </li>
+                ) : null}
+              </ol>
+              <hr />
+            </React.Fragment>
           ) : null}
 
           {params.stateId ? (

--- a/src/reports/Disclosure.jsx
+++ b/src/reports/Disclosure.jsx
@@ -104,40 +104,45 @@ class Disclosure extends React.Component {
           {header}
 
           {params.institutionId ? (
-            <ol className="ProgressCards usa-grid-full">
-              <li>
-                <ProgressCard
-                  title="institution"
-                  name={institution.name}
-                  id={institution.respondentId}
-                  link={`/disclosure-reports/${params.year}`}
-                />
-              </li>
-
-              {params.msaMdId ? (
+            <React.Fragment>
+              <ol className="ProgressCards usa-grid-full">
                 <li>
                   <ProgressCard
-                    title="MSA/MD"
-                    name={msaMd.name}
-                    id={msaMd.id}
-                    link={`/disclosure-reports/${params.year}/${institutionId}`}
+                    title="institution"
+                    name={institution.name}
+                    id={institution.respondentId}
+                    link={`/disclosure-reports/${params.year}`}
                   />
                 </li>
-              ) : null}
 
-              {params.reportId ? (
-                <li>
-                  <ProgressCard
-                    title="report"
-                    name={report.name}
-                    id={report.id}
-                    link={`/disclosure-reports/${
-                      params.year
-                    }/${institutionId}/${msaMd.id}`}
-                  />
-                </li>
-              ) : null}
-            </ol>
+                {params.msaMdId ? (
+                  <li>
+                    <ProgressCard
+                      title="MSA/MD"
+                      name={msaMd.name}
+                      id={msaMd.id}
+                      link={`/disclosure-reports/${
+                        params.year
+                      }/${institutionId}`}
+                    />
+                  </li>
+                ) : null}
+
+                {params.reportId ? (
+                  <li>
+                    <ProgressCard
+                      title="report"
+                      name={report.name}
+                      id={report.id}
+                      link={`/disclosure-reports/${
+                        params.year
+                      }/${institutionId}/${msaMd.id}`}
+                    />
+                  </li>
+                ) : null}
+              </ol>
+              <hr />
+            </React.Fragment>
           ) : null}
 
           {params.institutionId ? (

--- a/src/reports/Disclosure.jsx
+++ b/src/reports/Disclosure.jsx
@@ -91,7 +91,7 @@ class Disclosure extends React.Component {
       institution && (institution.institutionId || institution.id)
     const header = (
       <Header
-        type={2}
+        type={1}
         headingText="Disclosure reports"
         paragraphText="These reports summarize lending activity for individual
               institutions, both nationwide and by MSA/MD."
@@ -99,54 +99,63 @@ class Disclosure extends React.Component {
     )
 
     return this.state.fetched ? (
-      <>
+      <React.Fragment>
         <div className="usa-grid" id="main-content">
           {header}
+
           {params.institutionId ? (
-            <>
-              <ProgressCard
-                title="institution"
-                name={institution.name}
-                id={institution.respondentId}
-                link={`/disclosure-reports/${params.year}`}
-              />
-              {params.msaMdId ? (
-                <>
+            <React.Fragment>
+              <div className="ProgressCards usa-grid-full">
+                <ProgressCard
+                  title="institution"
+                  name={institution.name}
+                  id={institution.respondentId}
+                  link={`/disclosure-reports/${params.year}`}
+                />
+
+                {params.msaMdId ? (
                   <ProgressCard
                     title="MSA/MD"
                     name={msaMd.name}
                     id={msaMd.id}
                     link={`/disclosure-reports/${params.year}/${institutionId}`}
                   />
-                  {params.reportId ? (
-                    <>
-                      <ProgressCard
-                        title="report"
-                        name={report.name}
-                        id={report.id}
-                        link={`/disclosure-reports/${
-                          params.year
-                        }/${institutionId}/${msaMd.id}`}
-                      />
-                    </>
-                  ) : (
-                    <Reports {...this.props} />
-                  )}
-                </>
-              ) : (
-                <MsaMds
-                  {...this.props}
-                  fetchedMsas={fetchedMsas}
-                  selectorCallback={this.setMsaMd}
-                />
-              )}
-            </>
+                ) : null}
+
+                {params.reportId ? (
+                  <ProgressCard
+                    title="report"
+                    name={report.name}
+                    id={report.id}
+                    link={`/disclosure-reports/${
+                      params.year
+                    }/${institutionId}/${msaMd.id}`}
+                  />
+                ) : null}
+              </div>
+              <hr />
+            </React.Fragment>
+          ) : null}
+
+          {params.institutionId ? (
+            params.msaMdId ? (
+              params.reportId ? null : (
+                <Reports {...this.props} />
+              )
+            ) : (
+              <MsaMds
+                {...this.props}
+                fetchedMsas={fetchedMsas}
+                selectorCallback={this.setMsaMd}
+              />
+            )
           ) : (
             <SearchList makeListItem={this.makeListItem} />
           )}
         </div>
+
         {params.reportId ? <Report {...this.props} /> : null}
-      </>
+      </React.Fragment>
     ) : (
       <LoadingIcon />
     )

--- a/src/reports/Disclosure.jsx
+++ b/src/reports/Disclosure.jsx
@@ -104,25 +104,29 @@ class Disclosure extends React.Component {
           {header}
 
           {params.institutionId ? (
-            <React.Fragment>
-              <div className="ProgressCards usa-grid-full">
+            <ol className="ProgressCards usa-grid-full">
+              <li>
                 <ProgressCard
                   title="institution"
                   name={institution.name}
                   id={institution.respondentId}
                   link={`/disclosure-reports/${params.year}`}
                 />
+              </li>
 
-                {params.msaMdId ? (
+              {params.msaMdId ? (
+                <li>
                   <ProgressCard
                     title="MSA/MD"
                     name={msaMd.name}
                     id={msaMd.id}
                     link={`/disclosure-reports/${params.year}/${institutionId}`}
                   />
-                ) : null}
+                </li>
+              ) : null}
 
-                {params.reportId ? (
+              {params.reportId ? (
+                <li>
                   <ProgressCard
                     title="report"
                     name={report.name}
@@ -131,10 +135,9 @@ class Disclosure extends React.Component {
                       params.year
                     }/${institutionId}/${msaMd.id}`}
                   />
-                ) : null}
-              </div>
-              <hr />
-            </React.Fragment>
+                </li>
+              ) : null}
+            </ol>
           ) : null}
 
           {params.institutionId ? (

--- a/src/reports/ModifiedLar.jsx
+++ b/src/reports/ModifiedLar.jsx
@@ -6,7 +6,7 @@ const ModifiedLar = props => {
   return (
     <div className="usa-grid" id="main-content">
       <Header
-        type={2}
+        type={1}
         headingText="Modified Loan/Application Register (LAR)"
         paragraphText="A downloadable modified LAR file is available for every 
             financial institution that has completed a 2017 HMDA data submission. 

--- a/src/reports/ProgressCard.jsx
+++ b/src/reports/ProgressCard.jsx
@@ -11,9 +11,12 @@ const ProgressCard = ({ name, id, link, title }) => {
 
   return (
     <div className="ProgressCard">
-      <Header type={4} headingText={title} paragraphText={name + id}>
-        <Link to={link}>Select a different {title}</Link>
-      </Header>
+      <Header
+        type={4}
+        headingText={title}
+        paragraphText={name + id}
+        headingLink={link}
+      />
     </div>
   )
 }

--- a/src/reports/ProgressCard.jsx
+++ b/src/reports/ProgressCard.jsx
@@ -1,23 +1,29 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import Header from '../common/Header.jsx'
 
-const capitalize = str => str[0].toUpperCase() + str.slice(1)
 const ProgressCard = ({ name, id, link, title }) => {
   if (id === 'nationwide') {
     name = ''
-    id = capitalize(id)
   } else {
     name = name + ' - '
   }
 
+  let stepNumber = '1.'
+  if (title === 'MSA/MD') stepNumber = '2.'
+  if (title === 'report') stepNumber = '3.'
+
   return (
     <div className="ProgressCard usa-width-one-third">
-      <h5>{capitalize(title)}</h5>
-      <div>
-        {name}
-        {id}
-      </div>
-      <Link to={link}>Select a different {title}</Link>
+      <Header
+        type={4}
+        headingText={`${stepNumber} ${title}`}
+        paragraphText={name + id}
+      >
+        <p style={{ marginBottom: '0' }}>
+          <Link to={link}>Select a different {title}</Link>
+        </p>
+      </Header>
     </div>
   )
 }

--- a/src/reports/ProgressCard.jsx
+++ b/src/reports/ProgressCard.jsx
@@ -9,20 +9,10 @@ const ProgressCard = ({ name, id, link, title }) => {
     name = name + ' - '
   }
 
-  let stepNumber = '1.'
-  if (title === 'MSA/MD') stepNumber = '2.'
-  if (title === 'report') stepNumber = '3.'
-
   return (
-    <div className="ProgressCard usa-width-one-third">
-      <Header
-        type={4}
-        headingText={`${stepNumber} ${title}`}
-        paragraphText={name + id}
-      >
-        <p style={{ marginBottom: '0' }}>
-          <Link to={link}>Select a different {title}</Link>
-        </p>
+    <div className="ProgressCard">
+      <Header type={4} headingText={title} paragraphText={name + id}>
+        <Link to={link}>Select a different {title}</Link>
       </Header>
     </div>
   )

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -8,6 +8,9 @@
         margin-top: 0;
         text-transform: capitalize;
       }
+      p {
+        text-transform: capitalize;
+      }
     }
   }
 

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -1,9 +1,18 @@
-.ProgressCard {
-  background: $color-gray-lightest;
-  padding: 0.5em;
-  margin-bottom: 1em;
+.ProgressCards {
+  margin-bottom: 2em !important;
 
-  h5 {
-    margin-bottom: 0.25em;
+  hr {
+    border-top-color: $color-gray-lightest;
+    border-bottom: none;
+  }
+
+  .ProgressCard {
+    .header {
+      margin-bottom: 0;
+      h4 {
+        margin-top: 0;
+        text-transform: capitalize;
+      }
+    }
   }
 }

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -1,6 +1,7 @@
 .ProgressCards {
   margin-bottom: 2em !important;
   margin-left: 1em;
+
   .ProgressCard {
     .header {
       margin-bottom: 0;

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -1,11 +1,6 @@
 .ProgressCards {
   margin-bottom: 2em !important;
-
-  hr {
-    border-top-color: $color-gray-lightest;
-    border-bottom: none;
-  }
-
+  margin-left: 1em;
   .ProgressCard {
     .header {
       margin-bottom: 0;
@@ -14,5 +9,10 @@
         text-transform: capitalize;
       }
     }
+  }
+
+  li {
+    float: left;
+    width: 33.333%;
   }
 }

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -13,6 +13,10 @@
 
   li {
     float: left;
-    width: 33.333%;
+    margin-right: 2.35765%;
+    width: 31.76157%;
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }

--- a/src/reports/ProgressCard.scss
+++ b/src/reports/ProgressCard.scss
@@ -1,5 +1,4 @@
 .ProgressCards {
-  margin-bottom: 2em !important;
   margin-left: 1em;
 
   .ProgressCard {

--- a/src/reports/Report.jsx
+++ b/src/reports/Report.jsx
@@ -228,33 +228,29 @@ class Report extends React.Component {
       : null
     return (
       <div className="Report">
-        <Header type={4} headingText={headingText}>
-          {report ? (
-            <>
-              <p style={{ width: '50%', display: 'inline-block' }}>
+        <div className="usa-grid">
+          <Header type={3} headingText={headingText}>
+            {report ? (
+              <>
                 {report.respondentId ? (
-                  <span>
+                  <p>
                     Institution: {report.respondentId} -{' '}
                     {report.institutionName}
-                  </span>
+                  </p>
                 ) : null}
-              </p>
 
-              <p
-                style={{
-                  width: '50%',
-                  display: 'inline-block',
-                  textAlign: 'right'
-                }}
-              >
-                {report.msa
-                  ? `MSA/MD: ${report.msa.id} - ${report.msa.name}`
-                  : 'Nationwide'}
-              </p>
-            </>
-          ) : null}
-        </Header>
-        <button onClick={this.generateCSV}>Save as CSV</button>
+                {report.msa ? (
+                  <p>
+                    MSA/MD: {report.msa.id} - {report.msa.name}
+                  </p>
+                ) : (
+                  <p>Nationwide</p>
+                )}
+              </>
+            ) : null}
+          </Header>
+          <button onClick={this.generateCSV}>Save as CSV</button>
+        </div>
         {this.selectReport(report, reportType)}
         <p className="usa-text-small report-date">
           Report date: {report.reportDate}

--- a/src/reports/Report.jsx
+++ b/src/reports/Report.jsx
@@ -227,7 +227,7 @@ class Report extends React.Component {
         }`
       : null
     return (
-      <div className="report">
+      <div className="Report">
         <Header type={4} headingText={headingText}>
           {report ? (
             <>

--- a/src/reports/Report.scss
+++ b/src/reports/Report.scss
@@ -1,4 +1,5 @@
-.report {
+.Report {
+  margin-top: 2em;
   padding: 0 1em;
   overflow-x: auto;
   .report-date {

--- a/src/reports/Report.scss
+++ b/src/reports/Report.scss
@@ -1,5 +1,5 @@
 .Report {
-  margin-top: 4em;
+  margin-top: 2em;
   padding: 0 1em;
   overflow-x: auto;
   .report-date {
@@ -8,21 +8,16 @@
   }
 
   .header {
-    margin-bottom: 0 !important;
-    p {
-      color: $color-base;
-      font-weight: bold;
-      margin-bottom: 0;
-      margin-top: 1em;
-    }
-
-    h4 {
+    h3 {
       margin-top: 0;
+    }
+    p {
+      margin-bottom: 0;
     }
   }
 
   table {
-    margin-top: 0.5em;
+    margin-top: 3em;
     width: 100%;
     thead th {
       text-align: center;

--- a/src/reports/Report.scss
+++ b/src/reports/Report.scss
@@ -1,5 +1,5 @@
 .Report {
-  margin-top: 2em;
+  margin-top: 4em;
   padding: 0 1em;
   overflow-x: auto;
   .report-date {


### PR DESCRIPTION
Closes #131 

This does some cleanup to improve the heading area throughout the report workflow; for both aggregate and disclosure reports.

- groups the progress cards a little better, within an `<ol>`
- uses the `<ol>` to give an idea of steps similar to the filing application
- improves the spacing between each section
- cleans up the table header section

---

### Screenshot

![header-cleanup](https://user-images.githubusercontent.com/2932572/39888097-dec750e6-5461-11e8-844c-0e6ecacdddc3.png)
