### PR TITLE
use relative paths for api calls

### DIFF
--- a/src/reports/SearchList.jsx
+++ b/src/reports/SearchList.jsx
@@ -19,7 +19,7 @@ class SearchList extends React.Component {
 
   componentDidMount() {
     if (this.state.isLoading) {
-      isomorphicFetch('https://ffiec-api.cfpb.gov/public/filers')
+      isomorphicFetch('/v2/public/filers')
         .then(response => {
           if (response.ok) {
             return response.json()

--- a/src/reports/fetchMsas.js
+++ b/src/reports/fetchMsas.js
@@ -1,7 +1,7 @@
 import isomorphicFetch from 'isomorphic-fetch'
 
 function getMsaUrl(institutionId) {
-  return `https://ffiec-api.cfpb.gov/public/filers/2017/${institutionId}/msaMds`
+  return `/v2/public/filers/2017/${institutionId}/msaMds`
 }
 
 export default function(institutionId) {


### PR DESCRIPTION
The `v2` setup will let us use relative paths for API calls.