### PR TITLE
Push to dockerhub and internal repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
-     env.GIT_TAG = repo.GIT_TAG
      def shortGitCommit = "${gitCommit[0..10]}"
 
     stage('Build And Publish Docker Image') {
@@ -20,11 +19,11 @@ volumes: [
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
                 sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
-                if (env.GIT_TAG != "null" || gitBranch == "v2") {
+                if (env.TAG_NAME != "null" || gitBranch == "v2") {
                   if (gitBranch == "v2") {
                     env.DOCKER_TAG = "latest"
                   } else {
-                    env.DOCKER_TAG = gitTag
+                    env.DOCKER_TAG = env.TAG_NAME
                   }
                   sh """
                     docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui ${env.DOCKER_HUB_USER}/hmda-pub-ui:${env.DOCKER_TAG}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ volumes: [
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
                 sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
-                if (env.TAG_NAME != "null" || gitBranch == "v2") {
+                if (env.TAG_NAME != null || gitBranch == "v2") {
                   if (gitBranch == "v2") {
                     env.DOCKER_TAG = "latest"
                   } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
-     def gitTag = repo.GIT_TAG
+     env.GIT_TAG = repo.GIT_TAG
      def shortGitCommit = "${gitCommit[0..10]}"
 
     stage('Build And Publish Docker Image') {
@@ -20,9 +20,9 @@ volumes: [
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
                 sh 'env | sort'
-                println gitTag
+                println env.GIT_TAG
                 sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
-                if (gitTag != "null" || gitBranch == "v2") {
+                if (env.GIT_TAG != "null" || gitBranch == "v2") {
                   if (gitBranch == "v2") {
                     env.DOCKER_TAG = "latest"
                   } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
-     def gitTag = repo.GIT_TAG
      def shortGitCommit = "${gitCommit[0..10]}"
 
     stage('Build And Publish Docker Image') {
@@ -19,6 +18,7 @@ volumes: [
             withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'hmda-platform-jenkins-service',
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')])
+              sh 'env | sort'
               sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
               if (gitTag != "" || gitBranch == "v2") {
                 if (gitBranch == "v2") {
@@ -34,6 +34,7 @@ volumes: [
                 sh "docker push ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
               }
             }
+          }
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ volumes: [
                     docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui:${env.DOCKER_TAG} ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-pub-ui:${env.DOCKER_TAG}
                     docker login ${DOCKER_REGISTRY_URL} -u ${env.DTR_USER} -p ${env.DTR_PASSWORD} 
                     docker push ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-pub-ui:${env.DOCKER_TAG}
+                    docker image prune -f
                   """
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,16 +9,30 @@ volumes: [
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH
+     def gitTag = repo.GIT_TAG
      def shortGitCommit = "${gitCommit[0..10]}"
 
     stage('Build And Publish Docker Image') {
       container('docker') {
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'dockerhub',
             usernameVariable: 'DOCKER_HUB_USER', passwordVariable: 'DOCKER_HUB_PASSWORD']]) {
-              sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
-              sh "docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui ${env.DOCKER_HUB_USER}/hmda-pub-ui:${gitBranch}"
-              sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
-              sh "docker push ${env.DOCKER_HUB_USER}/hmda-pub-ui:${gitBranch}"
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'hmda-platform-jenkins-service',
+              usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
+              withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')])
+              if (gitTag != "" or gitBranch == "v2") {
+                if (gitBranch == "v2") {
+                  def dockerTag = "latest"
+                } else {
+                  def dockerTag = gitTag
+                }
+                sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
+                sh "docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui ${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
+                sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
+                sh "docker push ${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
+                sh "docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag} ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
+                sh "docker login ${DOCKER_REGISTRY_URL} -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
+                sh "docker push ${DOCKER_REGISTRY_URL}/${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
+              }
             }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,6 @@ volumes: [
             withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'hmda-platform-jenkins-service',
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')]){
-                sh 'env | sort'
-                println env.GIT_TAG
                 sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
                 if (env.GIT_TAG != "null" || gitBranch == "v2") {
                   if (gitBranch == "v2") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ volumes: [
           sh "helm upgrade --install --force \
           --namespace=default \
           --values=kubernetes/hmda-pub-ui/values.yaml \
-          --set image.tag=${gitBranch} \
+          --set image.tag=latest \
           hmda-pub-ui \
           kubernetes/hmda-pub-ui"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,13 +19,13 @@ volumes: [
             withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'hmda-platform-jenkins-service',
               usernameVariable: 'DTR_USER', passwordVariable: 'DTR_PASSWORD']]) {
               withCredentials([string(credentialsId: 'internal-docker-registry', variable: 'DOCKER_REGISTRY_URL')])
-              if (gitTag != "" or gitBranch == "v2") {
+              sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
+              if (gitTag != "" || gitBranch == "v2") {
                 if (gitBranch == "v2") {
                   def dockerTag = "latest"
                 } else {
                   def dockerTag = gitTag
                 }
-                sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-pub-ui ."
                 sh "docker tag ${env.DOCKER_HUB_USER}/hmda-pub-ui ${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"
                 sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
                 sh "docker push ${env.DOCKER_HUB_USER}/hmda-pub-ui:${dockerTag}"


### PR DESCRIPTION
This PR performs two functions:
1. pushes images to dockerhub and our internal docker registry
1. stops sending all images to dockerhub and instead just pushes master as `latest` and tagged branches to coincide with our release process.