### PR TITLE
2019 disclosure update to Report.jsx

### DIFF
--- a/src/reports/Report.jsx
+++ b/src/reports/Report.jsx
@@ -112,7 +112,7 @@ class Report extends React.Component {
     let year = params.year
     let msaMdId = params.msaMdId
     let reportId = params.reportId
-    const env = 'prod'
+    const env = 'dev'
     const ext = year === '2017' ? '.txt' : '.json'
     let url = `https://s3.amazonaws.com/cfpb-hmda-public/${env}/reports/`
     if (params.stateId) {
@@ -251,10 +251,10 @@ class Report extends React.Component {
     return (
       <div className="Report">
         <Header type={3} headingText={headingText}>
-          {report.respondentId ? (
-            <p>
-              Institution: {report.respondentId} - {report.institutionName}
-            </p>
+          {report.institutions ? report.institutions.map((institution, index)=>(
+              <p key={index}>
+              Institution: {institution}
+            </p>)
           ) : null}
 
           {report.msa ? (

--- a/src/reports/Report.jsx
+++ b/src/reports/Report.jsx
@@ -112,7 +112,7 @@ class Report extends React.Component {
     let year = params.year
     let msaMdId = params.msaMdId
     let reportId = params.reportId
-    const env = 'dev'
+    const env = 'prod'
     const ext = year === '2017' ? '.txt' : '.json'
     let url = `https://s3.amazonaws.com/cfpb-hmda-public/${env}/reports/`
     if (params.stateId) {


### PR DESCRIPTION
addresses issue : [275](https://github.com/cfpb/hmda-pub-ui/issues/275)

It looks like the renderer was configured to look for respondent-id/name instead of the new 2018 format which presents a list of institution names. Updated that section of code to map a list of institutions using the index as a unique key. 

<img width="1302" alt="Screen Shot 2019-04-19 at 12 09 16 PM" src="https://user-images.githubusercontent.com/44584592/56432630-12b85000-629c-11e9-9dcd-adcb955481bf.png">
