### PR TITLE
Updates to snapshot/dynamic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
 
+import { DYNAMIC_DATASET } from './constants/dynamic-dataset'
+import { SNAPSHOT_DATASET } from './constants/snapshot-dataset'
+
 import Header from './Header'
 import Home from './Home'
 import ModifiedLar from './reports/ModifiedLar'
@@ -38,11 +41,23 @@ const App = () => {
         />
         <Route
           path="/snapshot-national-loan-level-dataset/:year?"
-          component={Snapshot}
+          render={ props => {
+            const { year } = props.match.params
+            if(year && SNAPSHOT_DATASET.displayedYears.indexOf(year) === -1){
+              return <NotFound/>
+            }
+            return <Snapshot {...props}/>
+          }}
         />
         <Route
           path="/dynamic-national-loan-level-dataset/:year?"
-          component={DynamicDataset}
+          render={ props => {
+            const { year } = props.match.params
+            if(year && DYNAMIC_DATASET.displayedYears.indexOf(year) === -1){
+              return <NotFound/>
+            }
+            return <DynamicDataset {...props}/>
+          }}
         />
         <Route component={NotFound} />
       </Switch>

--- a/src/common/YearSelector.jsx
+++ b/src/common/YearSelector.jsx
@@ -4,19 +4,15 @@ import YEARS from '../constants/years'
 
 import './YearSelector.css'
 
-const YearSelector = withRouter(({ history, standalone, years='' }) => {
+const YearSelector = withRouter(({ history, standalone, years = YEARS }) => {
   const { pathname } = history.location
   const pathApp = pathname.split('/')[1]
   const pathYear = pathname.split('/')[2]
-  let renderYears = YEARS
-
-  if(years !== '')
-    renderYears = years.sort((a, b) => b - a)
 
   return (
     <div className={'YearSelector' + (standalone ? ' standalone' : '')}>
       <h4>Select a year</h4>
-      {renderYears.map((year, i) => {
+      {years.map((year, i) => {
         const className = year === pathYear ? 'active' : ''
         // just link to the current path if its the selected year
         // if it's a different year, jump back to the start for that year

--- a/src/constants/dynamic-dataset.js
+++ b/src/constants/dynamic-dataset.js
@@ -1,26 +1,15 @@
 export const DYNAMIC_DATASET = {
-  // '2019':
-  //   {
-  //      lar : "2019-lar",
-  //      ts : "2019-ts",
-  //      lar_spec : "2019-lar-specs",
-  //      ts_spec : "2019-ts-spec"
-  //   },
-  //
-  '2018':
-    {
-       lar : "2018-lar",
-       ts : "2018-ts",
-       lar_spec : "2018-lar-specs",
-       ts_spec : "2018-ts-spec"
-    },
-
-  '2017':
-    {
-       lar: "https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/2017_lar.txt",
-       ts : "https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/2017_ts.txt",
-       lar_spec : "https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv",
-       ts_spec : "https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv"
-    }
-
+  2018: {
+    lar : '2018-lar',
+    ts : '2018-ts',
+    lar_spec : '2018-lar-specs',
+    ts_spec : '2018-ts-spec'
+  },
+  2017: {
+    lar: 'https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/2017_lar.txt',
+    ts : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/dynamic-data/2017_ts.txt',
+    lar_spec : 'https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_LAR_Spec.csv',
+    ts_spec : 'https://github.com/cfpb/hmda-platform/blob/v1.x/Documents/2017_Dynamic_TS_Spec.csv'
+  },
+  displayedYears: ['2018', '2017']
 }

--- a/src/constants/snapshot-dataset.js
+++ b/src/constants/snapshot-dataset.js
@@ -1,47 +1,58 @@
 export const SNAPSHOT_DATASET = {
-  // '2019':
-  //   {
-  //      snapshot_date: "???",
-  //      public_lar_csv : "2019_public_lar_csv.zip",
-  //      public_lar_txt : "2019_public_lar_txt.zip",
-  //      public_ts_csv : "2019_public_ts_csv.zip",
-  //      public_ts_txt : "2019_public_ts_txt.zip",
-  //      public_panel_csv : "2019_public_panel_csv.zip",
-  //      public_panel_txt : "2019_public_panel_txt.zip",
-  //      public_msamd_csv : "2019_public_msamd_csv.zip",
-  //      public_msamd_txt : "2019_public_msamd_txt.zip",
-  //      publicstatic_dataformat : "2019_publicstatic_dataformat.pdf",
-  //      publicstatic_codesheet : "2019_publicstatic_codesheet.pdf"
-  //   },
-  //
-  '2018':
-    {
-       snapshot_date: "???",
-       public_lar_csv : "2018_public_lar_csv.zip",
-       public_lar_txt : "2018_public_lar_txt.zip",
-       public_ts_csv : "2018_public_ts_csv.zip",
-       public_ts_txt : "2018_public_ts_txt.zip",
-       public_panel_csv : "2018_public_panel_csv.zip",
-       public_panel_txt : "2018_public_panel_txt.zip",
-       public_msamd_csv : "2018_public_msamd_csv.zip",
-       public_msamd_txt : "2018_public_msamd_txt.zip",
-       publicstatic_dataformat : "2018_publicstatic_dataformat.pdf",
-       publicstatic_codesheet : "2018_publicstatic_codesheet.pdf"
-    },
-
-  '2017':
-    {
-       snapshot_date: "April 18th, 2018",
-       public_lar_csv : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_lar_csv.zip",
-       public_lar_txt : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_lar_txt.zip",
-       public_ts_csv : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_ts_csv.zip",
-       public_ts_txt : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_ts_txt.zip",
-       public_panel_csv : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_panel_csv.zip",
-       public_panel_txt : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_panel_txt.zip",
-       public_msamd_csv : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_msamd_csv.zip",
-       public_msamd_txt : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_msamd_txt.zip",
-       publicstatic_dataformat : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf",
-       publicstatic_codesheet : "https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf"
-    }
+  2018: {
+    snapshot_date: '???',
+    dataformat : '2018_publicstatic_dataformat.pdf',
+    codesheet : '2018_publicstatic_codesheet.pdf',
+    datasets: [
+      {
+        csv: '2018_public_lar_csv.zip',
+        txt: '2018_public_lar_txt.zip',
+        label: 'Loan/Application Records (LAR)'
+      },
+      {
+        csv : '2018_public_ts_csv.zip',
+        txt : '2018_public_ts_txt.zip',
+        label: 'Transmittal Sheet Records (TS)'
+      },
+      {
+        csv : '2018_public_panel_csv.zip',
+        txt : '2018_public_panel_txt.zip',
+        label: 'Reporter Panel'
+      },
+      {
+        csv : '2018_public_msamd_csv.zip',
+        txt : '2018_public_msamd_txt.zip',
+        label: 'MSA/MD Description'
+      }
+    ]
+  },
+  2017: {
+    snapshot_date: 'April 18th, 2018',
+    dataformat : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_dataformat.pdf',
+    codesheet : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_publicstatic_codesheet.pdf',
+    datasets: [
+      {
+        csv: 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_lar_csv.zip',
+        txt: 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_lar_txt.zip',
+        label: 'Loan/Application Records (LAR)'
+      },
+      {
+        csv : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_ts_csv.zip',
+        txt : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_ts_txt.zip',
+        label: 'Transmittal Sheet Records (TS)'
+      },
+      {
+        csv : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_panel_csv.zip',
+        txt : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_panel_txt.zip',
+        label: 'Reporter Panel'
+      },
+      {
+        csv : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_msamd_csv.zip',
+        txt : 'https://s3.amazonaws.com/cfpb-hmda-public/prod/snapshot-data/2017_public_msamd_txt.zip',
+        label: 'MSA/MD Description'
+      }
+    ]
+  },
+  displayedYears: ['2018', '2017']
 
 }

--- a/src/reports/DynamicDataset.jsx
+++ b/src/reports/DynamicDataset.jsx
@@ -5,93 +5,54 @@ import { DYNAMIC_DATASET } from '../constants/dynamic-dataset.js'
 
 import './DynamicDataset.css'
 
-class DynamicDataset extends React.Component {
-  constructor(props) {
-    super(props)
-    this.handleChange = this.handleChange.bind(this)
-  }
+function makeListLink(href, val) {
+  return (
+    <li>
+      <a download={true} href={href}>{val}</a>
+    </li>
+  )
+}
 
-  handleChange(val) {
-    this.props.history.push({
-      pathname: `${this.props.match.url}/${val.value}`
-    })
-  }
+const DynamicDataset = props => {
+  const { params } = props.match
+  const years = DYNAMIC_DATASET.displayedYears
+  const dataForYear = DYNAMIC_DATASET[params.year]
 
-  render() {
-    const { params } = this.props.match
-    const years = Object.keys(DYNAMIC_DATASET).map( v => parseInt(v))
+  return (
+    <div className="DynamicDataset" id="main-content">
+      <Header
+        type={1}
+        headingText="Dynamic National Loan-Level Dataset"
+        paragraphText="The dynamic files contain the national HMDA datasets for
+          all HMDA reporters, modified by the Bureau to protect applicant and
+          borrower privacy, updated to include late submissions and
+          resubmissions. The dynamic files are available to download in a pipe
+          delimited text file format. The dynamic datasets are updated on Mondays
+          with HMDA submissions received through the previous Sunday night."
+      />
 
-    // if year selected and a year that dosen't exist in constants, default to most recent
-    if(typeof params.year != 'undefined' && !DYNAMIC_DATASET.hasOwnProperty(params.year))
-      params.year = Math.max.apply(Math, years)
+      <YearSelector years={years} />
 
-    // load links
-    let dynamicLinks = DYNAMIC_DATASET[params.year]
-
-    return (
-      <div className="DynamicDataset" id="main-content">
-        <Header
-          type={1}
-          headingText="Dynamic National Loan-Level Dataset"
-          paragraphText="The dynamic files contain the national HMDA datasets for
-            all HMDA reporters, modified by the Bureau to protect applicant and
-            borrower privacy, updated to include late submissions and
-            resubmissions. The dynamic files are available to download in a pipe
-            delimited text file format. The dynamic datasets are updated on Mondays
-            with HMDA submissions received through the previous Sunday night."
-        />
-        {years.length > 1 ? <YearSelector years={years} /> : null }
-
-        {typeof params.year != 'undefined' ?
-          <div className="grid">
-            <div className="item">
-              <Header type={4} headingText={params.year + " Dynamic Datasets"} />
-              <ul>
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.lar}
-                  >
-                    Loan/Application Records (LAR)
-                  </a>
-                </li>
-
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.ts}
-                  >
-                    Transmittal Sheet Records (TS)
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div className="item">
-              <Header type={4} headingText={params.year + " Dynamic File Specifications"} />
-              <ul>
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.lar_spec}
-                  >
-                    Loan/Application Records (LAR)
-                  </a>
-                </li>
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.ts_spec}
-                  >
-                    Transmittal Sheet Records (TS)
-                  </a>
-                </li>
-              </ul>
-            </div>
+      {params.year ?
+        <div className="grid">
+          <div className="item">
+            <Header type={4} headingText={params.year + ' Dynamic Datasets'} />
+            <ul>
+              {makeListLink(dataForYear.lar, 'Loan/Application Records (LAR)')}
+              {makeListLink(dataForYear.ts, 'Transmittal Sheet Records (TS)')}
+            </ul>
           </div>
-          : null }
+          <div className="item">
+            <Header type={4} headingText={params.year + ' Dynamic File Specifications'} />
+            <ul>
+              {makeListLink(dataForYear.lar_spec, 'Loan/Application Records (LAR)')}
+              {makeListLink(dataForYear.ts_spec, 'Transmittal Sheet Records (TS)')}
+            </ul>
+          </div>
         </div>
-    )
-  }
+        : null }
+      </div>
+  )
 }
 
 export default DynamicDataset

--- a/src/reports/snapshot/Snapshot.css
+++ b/src/reports/snapshot/Snapshot.css
@@ -35,3 +35,7 @@
 .Snapshot .item:last-child {
   margin-right: 0;
 }
+
+.Snapshot .item li > ul {
+  margin-top: 0.5em;
+}

--- a/src/reports/snapshot/index.jsx
+++ b/src/reports/snapshot/index.jsx
@@ -4,171 +4,80 @@ import YearSelector from '../../common/YearSelector.jsx'
 import { SNAPSHOT_DATASET } from '../../constants/snapshot-dataset.js'
 import './Snapshot.css'
 
-class Snapshot extends React.Component {
-  constructor(props) {
-    super(props)
-    this.handleChange = this.handleChange.bind(this)
-  }
+function makeListLink(href, val) {
+  return (
+    <li>
+      <a download={true} href={href}>{val}</a>
+    </li>
+  )
+}
 
-  handleChange(val) {
-    this.props.history.push({
-      pathname: `${this.props.match.url}/${val.value}`
-    })
-  }
+function renderDatasets(datasets){
+  return (
+    <ul>
+      {datasets.map((dataset, i) => {
+        return (
+          <li key={i}>
+            {dataset.label}
+            <ul>
+              {makeListLink(dataset.csv, 'CSV')}
+              {makeListLink(dataset.txt, 'Pipe Delimited')}
+            </ul>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
 
-  render() {
-    const { params } = this.props.match
-    const years = Object.keys(SNAPSHOT_DATASET).map( v => parseInt(v))
+const Snapshot = props => {
+  const { params } = props.match
+  const years = SNAPSHOT_DATASET.displayedYears
+  const dataForYear = SNAPSHOT_DATASET[params.year]
+  const snapshotDate = params.year ? dataForYear.snapshot_date : 'a fixed date per year'
 
-    // if year selected and a year that dosen't exist in constants, default to most recent
-    if(typeof params.year != 'undefined' && !SNAPSHOT_DATASET.hasOwnProperty(params.year))
-      params.year = Math.max.apply(Math, years)
+  return (
+    <div className="Snapshot" id="main-content">
+      <Header
+        type={1}
+        headingText="Snapshot National Loan Level Dataset"
+        paragraphText={`The snapshot files contain the national HMDA datasets as of
+          ${snapshotDate} for all HMDA reporters, as modified by the Bureau to
+          protect applicant and borrower privacy. The snapshot files are available
+          to download in both .csv and pipe delimited text file formats, and the
+          file specification files are available to download in PDF format.`}>
+        <p className="text-small">
+          Snapshot data has preserved some elements of historic LAR data files
+          that are not present in the Dynamic Data. These columns are &quot;As of
+          Date&quot;, &quot;Edit Status&quot;, &quot;Sequence Number&quot;, and &quot;Application Date
+          Indicator&quot;. Be aware that data load procedures that handle both files
+          will need to recognize this difference.
+        </p>
+        <p className="text-small">
+          Use caution when analyzing loan amount and income, which do not have
+          an upper limit and may contain outliers.
+        </p>
+      </Header>
 
-    // load links
-    let dynamicLinks = SNAPSHOT_DATASET[params.year]
+      <YearSelector years={years} />
 
-    return (
-      <div className="Snapshot" id="main-content">
-        <Header
-          type={1}
-          headingText="Snapshot National Loan Level Dataset"
-          paragraphText="The snapshot files contain the national HMDA datasets as of
-            {dynamicLinks.snapshot_date} for all HMDA reporters, as modified by the Bureau to
-            protect applicant and borrower privacy. The snapshot files are available
-            to download in both .csv and pipe delimited text file formats, and the
-            file specification files are available to download in PDF format.">
-          <p className="text-small">
-            Snapshot data has preserved some elements of historic LAR data files
-            that are not present in the Dynamic Data. These columns are "As of
-            Date", "Edit Status", "Sequence Number", and "Application Date
-            Indicator". Be aware that data load procedures that handle both files
-            will need to recognize this difference.
-          </p>
-          <p className="text-small">
-            Use caution when analyzing loan amount and income, which do not have
-            an upper limit and may contain outliers.
-          </p>
-        </Header>
-
-        {years.length > 1 ? <YearSelector years={years} /> : null }
-
-        {typeof params.year != 'undefined' ?
-          <div className="grid">
-            <div className="item">
-              <Header type={4} headingText={params.year + " Datasets"} />
-              <ul>
-                <li>
-                  Loan/Application Records (LAR)
-                  <ul style={{ marginTop: '.5em' }}>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_lar_csv}
-                      >
-                        CSV
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_lar_txt}
-                      >
-                        Pipe Delimited
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  Transmittal Sheet Records (TS)
-                  <ul style={{ marginTop: '.5em' }}>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_ts_csv}
-                      >
-                        CSV
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_ts_txt}
-                      >
-                        Pipe Delimited
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  Reporter Panel
-                  <ul style={{ marginTop: '.5em' }}>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_panel_csv}
-                      >
-                        CSV
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_panel_txt}
-                      >
-                        Pipe Delimited
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  MSA/MD Description
-                  <ul style={{ marginTop: '.5em' }}>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_msamd_csv}
-                      >
-                        CSV
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        download={true}
-                        href={dynamicLinks.public_panel_txt}
-                      >
-                        Pipe Delimited
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </div>
-            <div className="item">
-              <Header type={4} headingText={params.years + " File Specifications"} />
-              <ul>
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.publicstatic_dataformat}
-                  >
-                    LAR, TS and Reporter Panel
-                  </a>
-                </li>
-                <li>
-                  <a
-                    download={true}
-                    href={dynamicLinks.publicstatic_codesheet}
-                  >
-                    LAR Code Sheet
-                  </a>
-                </li>
-              </ul>
-            </div>
+      { params.year ?
+        <div className="grid">
+          <div className="item">
+            <Header type={4} headingText={params.year + ' Datasets'} />
+            {renderDatasets(dataForYear.datasets)}
           </div>
-          : null }
-      </div>
-    )
-  }
+          <div className="item">
+            <Header type={4} headingText={params.year + ' File Specifications'} />
+            <ul>
+              {makeListLink(dataForYear.dataformat, 'LAR, TS and Reporter Panel')}
+              {makeListLink(dataForYear.codesheet, 'LAR Code Sheet')}
+            </ul>
+          </div>
+        </div>
+        : null }
+    </div>
+  )
 }
 
 export default Snapshot


### PR DESCRIPTION
In the wake of #306, this:
 -  fixes the `undefined` in file spec header and the literal snapshot text in the heading
 - generates list items from data (with some data reorg to facilitate this)
 - protects bad routes at the router level, sending the 404 page instead of the latest year